### PR TITLE
pre-commit: use shed to format Python opinionatedly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+minimum_pre_commit_version: '2.9.0'
+repos:
+- repo: https://github.com/Zac-HD/shed
+  rev: 0.9.4
+  hooks:
+    - id: shed
+      # args: [--refactor, --py39-plus]
+      types_or: [python, markdown, rst]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,5 +4,6 @@ repos:
   rev: 0.9.4
   hooks:
     - id: shed
-      # args: [--refactor, --py39-plus]
+      # TODO(pcohen): bump to --py310-plus when Talon moves to Python 3.10.
+      args: [--refactor, --py39-plus]
       types_or: [python, markdown, rst]


### PR DESCRIPTION
Taking a good suggestion from https://github.com/knausj85/knausj_talon/issues/666, let's set up [shed](https://github.com/Zac-HD/shed) to reformat our code in an opinionated fashion. It also sorts imports and removes unused imports, which was my main motivation. :)

This doesn't set up any enforcement yet -- I need to learn more about how to use GitHub Actions (will do that later). For now, let's just make sure we run `pre-commit run` at some point during development, or use `pre-commit install` to install the commit hook.

Also if we forget I'll just reformat and pushed directly to main/experimental, it's not a big deal. Just want to get alignment on the actual style.

This just adds the config to reduce merge conflicts between the two branches -- to see what it looks like in action, see https://github.com/phillco/talon_axkit/pull/11.