### PR TITLE
notification: extract subtitle

### DIFF
--- a/notification.py
+++ b/notification.py
@@ -73,11 +73,12 @@ class Notification:
         # XXX create_spoken_forms_from_list doesn't handle apostrophes correctly
         # https://github.com/knausj85/knausj_talon/issues/780
         group_actions = {
-            name.lower().replace("’", "'"): action for action, name in group_actions.items()
+            name.lower().replace("’", "'"): action
+            for action, name in group_actions.items()
         }
 
         title = body = subtitle = None
-        
+
         try:
             title = group.children.find_one(AXIdentifier="title").AXValue
         except ui.UIErr:
@@ -87,7 +88,7 @@ class Notification:
             body = group.children.find_one(AXIdentifier="body").AXValue
         except ui.UIErr:
             pass
-        
+
         try:
             subtitle = group.children.find_one(AXIdentifier="subtitle").AXValue
         except ui.UIErr:


### PR DESCRIPTION
The "subtitle" field is used in some notifications. For example, in Slack it's name of the person DMing you if the message comes from a different community, e.g. here "Slackbot"

<img width="370" alt="Screen Shot 2022-03-28 at 4 44 19 PM" src="https://user-images.githubusercontent.com/536668/160512687-7a55f262-a6cb-4452-8c7c-d56541629062.png">

Also rename `actions` to `group_actions` so it doesn't shadow the outer import name.
