### PR TITLE
office: Fix unintentional double assignment to ctx.matches.

### DIFF
--- a/dictation/app_overrides/office.py
+++ b/dictation/app_overrides/office.py
@@ -1,10 +1,6 @@
 from talon import Context, Module, ui, actions
 
 ctx = Context()
-ctx.matches = """
-os: mac
-app: messages
-"""
 mod = Module()
 
 mod.apps.excel_mac = """


### PR DESCRIPTION
Talon complains about this; it was a result of an errant copy-paste.