### PR TITLE
debugging, dictation: Guard talon.mac imports.

### DIFF
--- a/dictation/debugging.py
+++ b/dictation/debugging.py
@@ -2,7 +2,8 @@ import time
 import traceback
 
 from talon import Module, actions, app, cron, noise, ui
-if app.platform == 'mac':
+
+if app.platform == "mac":
     from talon.mac.ui import Element
 else:
     Element = type(None)

--- a/dictation/debugging.py
+++ b/dictation/debugging.py
@@ -1,11 +1,11 @@
 import time
 import traceback
 
-from talon import Module, actions, app, cron, noise, ui
+from talon import Module, actions, cron, noise, ui
 
-if app.platform == "mac":
+try:
     from talon.mac.ui import Element
-else:
+except ImportError:
     Element = type(None)
 
 HISS_DEBUG_ENABLED = True

--- a/dictation/debugging.py
+++ b/dictation/debugging.py
@@ -1,8 +1,11 @@
 import time
 import traceback
 
-from talon import Module, actions, cron, noise, ui
-from talon.mac.ui import Element
+from talon import Module, actions, app, cron, noise, ui
+if app.platform == 'mac':
+    from talon.mac.ui import Element
+else:
+    Element = type(None)
 
 HISS_DEBUG_ENABLED = True
 

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -4,7 +4,8 @@ from enum import Enum
 from typing import Optional
 
 from talon import Context, Module, actions, app, ui
-if app.platform == 'mac':
+
+if app.platform == "mac":
     from talon.mac.ui import Element
 else:
     Element = type(None)

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -3,8 +3,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from talon import Context, Module, actions, ui
-from talon.mac.ui import Element
+from talon import Context, Module, actions, app, ui
+if app.platform == 'mac':
+    from talon.mac.ui import Element
+else:
+    Element = type(None)
 from talon.types import Span
 
 ctx = Context()

--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -3,11 +3,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from talon import Context, Module, actions, app, ui
+from talon import Context, Module, actions, ui
 
-if app.platform == "mac":
+try:
     from talon.mac.ui import Element
-else:
+except ImportError:
     Element = type(None)
 from talon.types import Span
 


### PR DESCRIPTION
Allow these modules to be silently imported (if inert) on other platforms.