### PR TITLE
pre-commit: add flynt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         args: [--refactor, --py39-plus]
         types_or: [python, markdown, rst]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -19,3 +19,7 @@ repos:
     hooks:
       - id: prettier
         files: ".*.(md|json|yaml)$"
+  - repo: https://github.com/ikamensh/flynt/
+    rev: "0.76"
+    hooks:
+      - id: flynt


### PR DESCRIPTION
Flynt converts older versions of string interpolation to f-strings.

Since we [plan to](https://github.com/knausj85/knausj_talon/issues/816) also use it in knausj, let's add it here too for beta testing. Although we don't have any old-style strings to fix up, so there were no changes applied.

I also ran `pre-commit autoupdate` which upgraded https://github.com/pre-commit/pre-commit-hooks.