### PR TITLE
"note <number> actions" to display a notification action cheat sheet.

### DIFF
--- a/notification.py
+++ b/notification.py
@@ -291,6 +291,8 @@ class NotificationMonitor:
 
             frame = group.AXFrame
             break
+        else:
+            return
 
         gui_actions.x = frame.left - 300
         gui_actions.y = frame.top

--- a/notification.talon
+++ b/notification.talon
@@ -3,6 +3,12 @@ os: mac
 ^(note | notification) <number_small> {user.notification_actions}$:
 	user.notification_action(number_small - 1, notification_actions)
 
+^(note | notification) <number_small> actions$:
+	user.notification_show_actions(number_small - 1)
+
+^(note | notification) actions$:
+	user.notification_show_actions(-1)
+
 ^(note | notification) {user.notification_actions} <number_small>$:
 	user.notification_action(number_small - 1, notification_actions)
 


### PR DESCRIPTION
Also fixes a bug where notifications were accessed in the wrong order.
