### PR TITLE
dictation_context: check setting before attempting to grab current element

### DIFF
--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -115,6 +115,9 @@ class Actions:
 
     def dictation_peek_left(clobber=False):
         try:
+            if not setting_accessibility_dictation.get():
+                return actions.next()
+
             el = actions.user.dictation_current_element()
             context = actions.user.accessibility_create_dictation_context(el)
             if context is None:
@@ -135,6 +138,9 @@ class Actions:
 
     def dictation_peek_right():
         try:
+            if not setting_accessibility_dictation.get():
+                return actions.next()
+
             el = actions.user.dictation_current_element()
             context = actions.user.accessibility_create_dictation_context(el)
             if context is None:


### PR DESCRIPTION
Context: https://talonvoice.slack.com/archives/G8J6HDR6C/p1658803696161089

Grabbing the current element can raise an exception if it doesn't exist, so we should probably test the setting first.