### PR TITLE
dictation_peek_left: update method signature

### DIFF
--- a/dictation/dictation_context.py
+++ b/dictation/dictation_context.py
@@ -113,7 +113,7 @@ class Colors(Enum):
 class Actions:
     """Wires this into the knausj dictation formatter"""
 
-    def dictation_peek_left(clobber=False):
+    def dictation_peek_left():
         try:
             if not setting_accessibility_dictation.get():
                 return actions.next()


### PR DESCRIPTION
Clobber was removed in https://github.com/knausj85/knausj_talon/pull/915, so without this change axkit this throws a type error after merging past that knausj version:

```
talon.scripting.types.ActionImplError: Function 'user.dictation_peek_left' incompatible with prototype 'user.dictation_peek_left'
  Signature: (clobber=False)
  Expected:  () -> Optional[str]
  - Parameter count mismatch. Found 1, expected 0
```

Note that I think this means that users must merge this axkit commit and that knausj commit at the same time.