### PR TITLE
all: reformat Talon using `talonfmt`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,15 @@ repos:
     rev: "0.76"
     hooks:
       - id: flynt
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.3.0
+    hooks:
+      - id: remove-tabs
+        types: [file]
+        files: \.talon$
+        args: ["--whitespaces-count=4"]
+  - repo: https://github.com/wenkokke/talonfmt
+    rev: 1.7.0
+    hooks:
+      - id: talonfmt
+        args: ["--in-place", "--max-line-width=100"]

--- a/notification.talon
+++ b/notification.talon
@@ -1,26 +1,23 @@
 os: mac
 -
 ^(note | notification) <number_small> {user.notification_actions}$:
-	user.notification_action(number_small - 1, notification_actions)
+    user.notification_action(number_small - 1, notification_actions)
 
-^(note | notification) <number_small> actions$:
-	user.notification_show_actions(number_small - 1)
+^(note | notification) <number_small> actions$: user.notification_show_actions(number_small - 1)
 
-^(note | notification) actions$:
-	user.notification_show_actions(-1)
+^(note | notification) actions$: user.notification_show_actions(0 - 1)
 
 ^(note | notification) {user.notification_actions} <number_small>$:
-	user.notification_action(number_small - 1, notification_actions)
+    user.notification_action(number_small - 1, notification_actions)
 
 ^(note | notification) {user.notification_actions} {user.notification_apps}$:
-	user.notification_app_action(notification_apps, notification_actions)
+    user.notification_app_action(notification_apps, notification_actions)
 
 ^(note | notification) {user.notification_apps} {user.notification_actions}$:
-	user.notification_app_action(notification_apps, notification_actions)
+    user.notification_app_action(notification_apps, notification_actions)
 
-^(note | notification) update$:
-	user.notifications_update()
+^(note | notification) update$: user.notifications_update()
 
 ^(note | notification) center$:
-	user.notification_center()
-	user.notifications_update()
+    user.notification_center()
+    user.notifications_update()

--- a/window_action.talon
+++ b/window_action.talon
@@ -1,11 +1,11 @@
 os: mac
---
-
-{user.window_actions} window: user.action_windows(user.window_actions, 1, 0)
+-- {user.window_actions} window: user.action_windows(user.window_actions, 1, 0)
 {user.window_actions} other windows: user.action_windows(user.window_actions, 0, 1)
 {user.window_actions} [all] windows: user.action_windows(user.window_actions, 1, 1)
-{user.window_actions} all <user.running_applications> windows: user.action_windows(user.window_actions, 1, 1, user.running_applications)
-{user.window_actions} other <user.running_applications> windows: user.action_windows(user.window_actions, 0, 1, user.running_applications)
+{user.window_actions} all <user.running_applications> windows:
+    user.action_windows(user.window_actions, 1, 1, user.running_applications)
+{user.window_actions} other <user.running_applications> windows:
+    user.action_windows(user.window_actions, 0, 1, user.running_applications)
 
 fullscreen enter: user.action_windows("fullscreen", 1, 0)
 fullscreen exit: key(cmd-ctrl-f)

--- a/window_action.talon
+++ b/window_action.talon
@@ -1,5 +1,6 @@
 os: mac
--- {user.window_actions} window: user.action_windows(user.window_actions, 1, 0)
+-
+{user.window_actions} window: user.action_windows(user.window_actions, 1, 0)
 {user.window_actions} other windows: user.action_windows(user.window_actions, 0, 1)
 {user.window_actions} [all] windows: user.action_windows(user.window_actions, 1, 1)
 {user.window_actions} all <user.running_applications> windows:

--- a/window_doc.talon
+++ b/window_doc.talon
@@ -1,5 +1,6 @@
 os: mac
--- document open: user.open_current_doc()
+-
+document open: user.open_current_doc()
 document open in <user.launch_applications>: user.open_current_doc_in_app(user.launch_applications)
 document open in <user.running_applications>:
     user.open_current_doc_in_app(user.running_applications)

--- a/window_doc.talon
+++ b/window_doc.talon
@@ -1,8 +1,7 @@
 os: mac
---
-
-document open: user.open_current_doc()
+-- document open: user.open_current_doc()
 document open in <user.launch_applications>: user.open_current_doc_in_app(user.launch_applications)
-document open in <user.running_applications>: user.open_current_doc_in_app(user.running_applications)
-document (reveal|show): user.reveal_current_doc()
+document open in <user.running_applications>:
+    user.open_current_doc_in_app(user.running_applications)
+document (reveal | show): user.reveal_current_doc()
 document copy path: user.copy_current_doc_path()


### PR DESCRIPTION
Similar to https://github.com/knausj85/knausj_talon/pull/947, let's use `talonfmt`, although I prefer a slightly longer maximum line length.

Note that one change to `notification.talon` is working around a parser issue: https://github.com/wenkokke/talonfmt/issues/17