### PR TITLE
window_action: use appscript to close all windows

### DIFF
--- a/window_action.py
+++ b/window_action.py
@@ -30,7 +30,7 @@ def close_windows_via_appscript(app: App) -> bool:
     try:
         windows = app.appscript().windows
     except AttributeError:
-        # Application doesn't expose a scripting interface.
+        # Application doesn't expose a scripting interface, or `windows`.
         return False
 
     try:


### PR DESCRIPTION
I noticed that stuff like "window close all" in applications like Finder was really slow and flaky, and would often result in several windows being left open if you had a lot open (probably because they technically treat tabs as windows).

I was poking around with AppleScript and noticed that it's actually much faster and more reliable to just close all of the windows that way, ie with:

```
tell application "Finder"
	close every window
end tell
```

It fixes the Finder issue, and even in applications previously behaved well, there is an improvement (all windows close immediately, rather than a cascade of closures as it iterates through them). So let's use that!

I didn't do much to improve the "current window" and "other windows" use cases, although it probably not much work. I just wanted to knock this out quickly.