### PR TITLE
window_action: add noun-verb variants

### DIFF
--- a/window_action.talon
+++ b/window_action.talon
@@ -1,12 +1,12 @@
 os: mac
 -
 
-# Targeting the windows of the current application:
+# Targeting the windows of the current application (e.g. "window close other", "window minimize"):
 window {user.window_actions}: user.action_windows(user.window_actions, 1, 0)
 window {user.window_actions} other: user.action_windows(user.window_actions, 0, 1)
 window {user.window_actions} all: user.action_windows(user.window_actions, 1, 1)
 
-# Targeting the windows of any arbitrary application:
+# Targeting the windows of any arbitrary application (e.g. "Finder window close all"):
 <user.running_applications> window {user.window_actions}:
     user.action_windows(user.window_actions, 1, 0, user.running_applications)
 <user.running_applications> window {user.window_actions} other:

--- a/window_action.talon
+++ b/window_action.talon
@@ -7,11 +7,11 @@ window {user.window_actions} other: user.action_windows(user.window_actions, 0, 
 window {user.window_actions} all: user.action_windows(user.window_actions, 1, 1)
 
 # Targeting the windows of any arbitrary application (e.g. "Finder window close all"):
-<user.running_applications> window {user.window_actions}:
+from <user.running_applications> window {user.window_actions}:
     user.action_windows(user.window_actions, 1, 0, user.running_applications)
-<user.running_applications> window {user.window_actions} other:
+from <user.running_applications> window {user.window_actions} other:
     user.action_windows(user.window_actions, 0, 1, user.running_applications)
-<user.running_applications> window {user.window_actions} all:
+from <user.running_applications> window {user.window_actions} all:
     user.action_windows(user.window_actions, 1, 1, user.running_applications)
 
 # Entering and exiting fullscreen mode.

--- a/window_action.talon
+++ b/window_action.talon
@@ -6,7 +6,7 @@ window {user.window_actions}: user.action_windows(user.window_actions, 1, 0)
 window {user.window_actions} other: user.action_windows(user.window_actions, 0, 1)
 window {user.window_actions} all: user.action_windows(user.window_actions, 1, 1)
 
-# Targeting the windows of any arbitrary application (e.g. "Finder window close all"):
+# Targeting the windows of any arbitrary application (e.g. "from Finder window close all"):
 from <user.running_applications> window {user.window_actions}:
     user.action_windows(user.window_actions, 1, 0, user.running_applications)
 from <user.running_applications> window {user.window_actions} other:

--- a/window_action.talon
+++ b/window_action.talon
@@ -1,5 +1,26 @@
 os: mac
 -
+
+# Targeting the windows of the current application:
+window {user.window_actions}: user.action_windows(user.window_actions, 1, 0)
+window {user.window_actions} other: user.action_windows(user.window_actions, 0, 1)
+window {user.window_actions} all: user.action_windows(user.window_actions, 1, 1)
+
+# Targeting the windows of any arbitrary application:
+<user.running_applications> window {user.window_actions}:
+    user.action_windows(user.window_actions, 1, 0, user.running_applications)
+<user.running_applications> window {user.window_actions} other:
+    user.action_windows(user.window_actions, 0, 1, user.running_applications)
+<user.running_applications> window {user.window_actions} all:
+    user.action_windows(user.window_actions, 1, 1, user.running_applications)
+
+# Entering and exiting fullscreen mode.
+fullscreen enter: user.action_windows("fullscreen", 1, 0)
+<user.running_applications> fullscreen enter:
+    user.action_windows("fullscreen", 1, 0, user.running_applications)
+fullscreen exit: key(cmd-ctrl-f)
+
+# Legacy commands which use verb-noun:
 {user.window_actions} window: user.action_windows(user.window_actions, 1, 0)
 {user.window_actions} other windows: user.action_windows(user.window_actions, 0, 1)
 {user.window_actions} [all] windows: user.action_windows(user.window_actions, 1, 1)
@@ -7,6 +28,3 @@ os: mac
     user.action_windows(user.window_actions, 1, 1, user.running_applications)
 {user.window_actions} other <user.running_applications> windows:
     user.action_windows(user.window_actions, 0, 1, user.running_applications)
-
-fullscreen enter: user.action_windows("fullscreen", 1, 0)
-fullscreen exit: key(cmd-ctrl-f)


### PR DESCRIPTION
In https://github.com/phillco/talon-axkit/pull/55 it was pointed out that the existing commands used verb-noun, which is less standard.

Also added the missing `<user.running_applications> window {user.window_actions}`, so you can target (close or minimize) the most recent window of another application. More situational, but I don't see a reason not to fill out the matrix.

The fullscreen logic needs a little work after this. Filed https://github.com/phillco/talon-axkit/issues/57