### PR TITLE
macos_defaults: don't trust an empty selection

### DIFF
--- a/macos_defaults.py
+++ b/macos_defaults.py
@@ -79,14 +79,16 @@ class Actions:
 
     def selected_text() -> str:
         try:
-            return ui.focused_element().AXSelectedText
-        except Exception:
-            try:
-                # ui.focused_element() sometimes returns NoElement.
-                # https://github.com/talonvoice/talon/issues/480
+            selected_text = ui.focused_element().AXSelectedText
+            if not selected_text:
+                # Some partially-accessible applications incorrectly report empty selections sometimes, and this can be
+                # quite bad depending on the use case. For maximum safety we have to fall back to the clipboard
+                # implementation in this case. This could be customized if we knew the application was fully
+                # trustworthy.
                 #
-                # TODO(pcohen): extract this focused_element() -> AXFocusedUIElement fallback
-                # if we expect to need it in the future.
-                return ui.active_app().element.AXFocusedUIElement.AXSelectedText
-            except Exception:
+                # See https://github.com/phillco/talon-axkit/issues/59
                 return actions.next()
+
+            return selected_text
+        except Exception:
+            return actions.next()


### PR DESCRIPTION
Fixes https://github.com/phillco/talon-axkit/issues/59; see that issue for context. tldr: VS Code has started (when?) to report some partial accessibility information, which unfortunately only includes the selected text sometimes. Sometimes it says it is empty when it isn't.

In the future I could see us having a setting to adjust this behavior that could be turned on for fully native text fields that don't do what VS Code is doing, but in the interim, I think this is reasonable?

Also remove a fallback for <0.3 that's no longer needed.