### PR TITLE
window_action.talon: focus application when going full screen

### DIFF
--- a/window_action.talon
+++ b/window_action.talon
@@ -17,6 +17,7 @@ from <user.running_applications> window {user.window_actions} all:
 # Entering and exiting fullscreen mode.
 fullscreen enter: user.action_windows("fullscreen", 1, 0)
 <user.running_applications> fullscreen enter:
+    user.switcher_focus(user.running_applications)
     user.action_windows("fullscreen", 1, 0, user.running_applications)
 fullscreen exit: key(cmd-ctrl-f)
 


### PR DESCRIPTION
There's an action to make a arbitrary application fullscreen, but it doesn't actually work properly if that application isn't the focused one, so let's focus it first.

After this you can do something like "slack fullscreen enter" regardless of what program you have focused (although that's kind of a painful grammar -- suggestions welcome.)

Also filed https://github.com/phillco/talon-axkit/issues/62 to make this work better if another program is already fullscreen.