### PR TITLE
Work around longstanding core Talon issue in which notification windows aren't returned sometimes

### DIFF
--- a/notification.py
+++ b/notification.py
@@ -211,7 +211,8 @@ class NotificationMonitor:
 
     def notification_groups(self):
         ncui = ui.apps(pid=self.pid)[0]
-        for window in ncui.windows():
+        # XXX(nriley) Would use ncui.windows() but sometimes Talon loses track of them
+        for window in ncui.element.children.find(AXRole="AXWindow", max_depth=0):
             for group in window.children.find(AXRole="AXGroup"):
                 if not (identifier := Notification.group_identifier(group)):
                     continue


### PR DESCRIPTION
Once dynamic lists are a (stable) thing I should rearchitect this so it fetches the actions on demand. But in the meantime this at least helps with a common problem in which Talon can't find any notifications since the NCUI window isn't returned by `ncui.windows()`.