### PR TITLE
Use cursorless-dev/talon-tools talon formatter and update flynt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
     hooks:
       - id: prettier
         files: ".*.(md|json|yaml)$"
-  - repo: https://github.com/ikamensh/flynt/
-    rev: "0.78"
+  - repo: https://github.com/ikamensh/flynt
+    rev: "1.0.6"
     hooks:
       - id: flynt
   - repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,7 @@ repos:
         types: [file]
         files: \.talon$
         args: ["--whitespaces-count=4"]
-  - repo: https://github.com/wenkokke/talonfmt
-    rev: 1.10.2
+  - repo: https://github.com/cursorless-dev/talon-tools
+    rev: v0.11.0
     hooks:
-      - id: talonfmt
-        args: ["--in-place", "--max-line-width=88"]
+      - id: talon-fmt

--- a/inspect.talon
+++ b/inspect.talon
@@ -1,5 +1,6 @@
 os: mac
 -
+
 element hierarchy: user.element_print_hierarchy_at_mouse_pos(false, false)
 element hierarchy more: user.element_print_hierarchy_at_mouse_pos(true, false)
 element hierarchy all: user.element_print_hierarchy_at_mouse_pos(true, true)

--- a/macos_defaults.py
+++ b/macos_defaults.py
@@ -63,14 +63,12 @@ class user_actions:
             return
 
         escaped_path = path.replace(r'"', r"\"")
-        applescript.run(
-            rf"""
+        applescript.run(rf"""
             tell application id "{settings.get('user.preferred_terminal')}"
                 activate
                 open "{escaped_path}"
             end tell
-        """
-        )
+        """)
 
 
 @ctx.action_class("edit")

--- a/notification.talon
+++ b/notification.talon
@@ -1,5 +1,6 @@
 os: mac
 -
+
 ^(note | notification) <number_small> {user.notification_actions}$:
     user.notification_action(number_small - 1, notification_actions)
 

--- a/talon_helpers.talon
+++ b/talon_helpers.talon
@@ -1,5 +1,6 @@
 os: mac
 -
+
 ^talon copy menu select: user.copy_menu_select()
 ^talon copy menu key: user.copy_menu_key()
 ^talon copy menu key pie: user.copy_menu_key_python()

--- a/window_action.talon
+++ b/window_action.talon
@@ -3,7 +3,8 @@ os: mac
 
 # Targeting the windows of the current application (e.g. "window close other", "window minimize"):
 window {user.window_actions}: user.action_windows(user.window_actions, 1, 0)
-window {user.window_actions} other: user.action_windows(user.window_actions, 0, 1)
+window {user.window_actions} other:
+    user.action_windows(user.window_actions, 0, 1)
 window {user.window_actions} all: user.action_windows(user.window_actions, 1, 1)
 
 # Targeting the windows of any arbitrary application (e.g. "from Finder window close all"):
@@ -22,8 +23,10 @@ fullscreen exit: key(cmd-ctrl-f)
 
 # Legacy commands which use verb-noun:
 {user.window_actions} window: user.action_windows(user.window_actions, 1, 0)
-{user.window_actions} other windows: user.action_windows(user.window_actions, 0, 1)
-{user.window_actions} [all] windows: user.action_windows(user.window_actions, 1, 1)
+{user.window_actions} other windows:
+    user.action_windows(user.window_actions, 0, 1)
+{user.window_actions} [all] windows:
+    user.action_windows(user.window_actions, 1, 1)
 {user.window_actions} all <user.running_applications> windows:
     user.action_windows(user.window_actions, 1, 1, user.running_applications)
 {user.window_actions} other <user.running_applications> windows:

--- a/window_doc.talon
+++ b/window_doc.talon
@@ -1,5 +1,6 @@
 os: mac
 -
+
 document open: user.open_current_doc()
 document open in <user.launch_applications>:
     user.open_current_doc_in_app(user.launch_applications)


### PR DESCRIPTION
Fixes pre-commit.ci error: "Package 'talonfmt' requires a different Python: 3.14.4 not in '<3.13,>=3.9'"

The new hook aligns with talonhub/community. If you want to preserve the old max line length, we can do that via .editorconfig.